### PR TITLE
Add GitHub Pages hosting instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,8 @@
 This repository contains the portfolio site for **Abhijeet Pawar**. The site showcases work experience, projects and certifications in cybersecurity.
 
 Open `index.html` in your browser to view the portfolio.
+
+## Hosting on GitHub Pages
+1. Push the repository to GitHub.
+2. In the repository’s **Settings → Pages**, select branch "main" and folder "/ (root)".
+3. Save to publish the site at `https://<username>.github.io/<repository>`.


### PR DESCRIPTION
## Summary
- describe how to publish the portfolio site on GitHub Pages

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684dd02e2d808325ae00e11ce4cb1fb2